### PR TITLE
Consistent genconfig script name

### DIFF
--- a/roles/DCOS.bootstrap/tasks/main.yml
+++ b/roles/DCOS.bootstrap/tasks/main.yml
@@ -57,6 +57,7 @@
 - name: Setting download dir
   set_fact:
      download_path: "{{ download_base_dir }}/{{ dcos_version_specifier }}"
+     install_file: "{{ dcos['download']|basename }}"
 
 - name: "create install directory/genconf"
   file: path={{ download_path }}/genconf state=directory mode=0755
@@ -66,7 +67,7 @@
 - name: download installation file
   get_url:
     url: "{{ dcos['download'] }}"
-    dest: "{{ download_path }}/dcos_generate_config.ee.sh"
+    dest: "{{ download_path }}/{{ install_file }}"
     mode: 0440
 
 # vvv POST DOWNLOAD / configuration vvv
@@ -108,7 +109,7 @@
 # vvv GENERATE INSTALLER vvv
 
 - name: generate DC/OS bootstrap files
-  command: "bash dcos_generate_config.ee.sh"
+  command: "bash {{ install_file }}"
   args:
     chdir: "{{ download_path }}"
     creates: "{{ download_path }}/genconf/serve/dcos_install.sh"
@@ -116,7 +117,7 @@
 # vvv GENERATE UPGRADE SCRIPTS vvv
 - name: generate DC/OS upgrade files
   shell: >
-    bash dcos_generate_config.ee.sh --generate-node-upgrade-script {{ dcos['version_to_upgrade_from'] }};
+    bash {{ install_file }} --generate-node-upgrade-script {{ dcos['version_to_upgrade_from'] }};
     mv genconf/serve/upgrade genconf/serve/upgrade_from_{{ dcos['version_to_upgrade_from'] }}
   args:
     warn: false


### PR DESCRIPTION
Config script keeps consistent name to avoid confusion

related to #1 