### PR TITLE
add seconds to double check the prefix/cluster name and version task

### DIFF
--- a/roles/DCOS.bootstrap/tasks/main.yml
+++ b/roles/DCOS.bootstrap/tasks/main.yml
@@ -21,6 +21,7 @@
 
 - name: double check the prefix/cluster name and version
   pause:
+    seconds: 30
     prompt: |
         Please double check the prefix/cluster name and version of this cluster:
 


### PR DESCRIPTION
This is simply to  bring up a discussion. Thinking along the lines of CI work and using these roles. Should we consider adding an "auto approve" approach where there is not a requirement for a user to have to interact to proceed? Currently, the user must give the go ahead or the prompt will sit in a pause. Something like 30 seconds (or whatever amount of time) would still give the user plenty of time to cancel the run if they were not satisfied with the output, while still allowing a hands off approach for automation.

Just a thought. I can see arguments to including or not. Of course always possible for users to create something to automate this process but should we include something out of the box with this experience? 