### PR TITLE
Dynamic upgrades: Allows multiple versions DC/OS to be upgraded at the same time

### DIFF
--- a/dcos.yml
+++ b/dcos.yml
@@ -1,4 +1,10 @@
 ---
+- name: Collect DC/OS versions
+  hosts: all
+  tasks:
+    - name: Collect DC/OS versions
+      setup:
+
 - name: DC/OS Requirements
   hosts: all
   become: true

--- a/group_vars/all/dcos.yaml.example
+++ b/group_vars/all/dcos.yaml.example
@@ -2,7 +2,6 @@
 dcos:
   download: "https://downloads.dcos.io/dcos/stable/1.12.0/dcos_generate_config.sh"
   version: "1.12.0"
-  version_to_upgrade_from: "1.12.0-beta1"
   # image_commit: "acc9fe548aea5b1b5b5858a4b9d2c96e07eeb9de"
   enterprise_dcos: false
 

--- a/molecule/ec2/install_1-12_upgrade_1-12.yml
+++ b/molecule/ec2/install_1-12_upgrade_1-12.yml
@@ -61,7 +61,6 @@
     dcos:
       download: "https://downloads.dcos.io/dcos/testing/1.12/commit/3b8b3837cd12bdbc0853e5cd9e0d635b8ba83623/dcos_generate_config.sh"
       version: "1.12.0"
-      version_to_upgrade_from: "1.12.0"
       image_commit: "3b8b3837cd12bdbc0853e5cd9e0d635b8ba83623"
       config:
         bootstrap_url: "http://{{ hostvars[groups['bootstraps'][0]].ansible_facts.default_ipv4.address }}:8080"
@@ -78,7 +77,6 @@
     dcos:
       download: "https://downloads.dcos.io/dcos/testing/1.12/commit/3b8b3837cd12bdbc0853e5cd9e0d635b8ba83623/dcos_generate_config.sh"
       version: "1.12.0"
-      version_to_upgrade_from: "1.12.0"
       image_commit: "3b8b3837cd12bdbc0853e5cd9e0d635b8ba83623"
       config:
         bootstrap_url: "http://{{ hostvars[groups['bootstraps'][0]].ansible_facts.default_ipv4.address }}:8080"
@@ -94,7 +92,6 @@
     dcos:
       download: "https://downloads.dcos.io/dcos/testing/1.12/commit/3b8b3837cd12bdbc0853e5cd9e0d635b8ba83623/dcos_generate_config.sh"
       version: "1.12.0"
-      version_to_upgrade_from: "1.12.0"
       image_commit: "3b8b3837cd12bdbc0853e5cd9e0d635b8ba83623"
       config:
         bootstrap_url: "http://{{ hostvars[groups['bootstraps'][0]].ansible_facts.default_ipv4.address }}:8080"

--- a/molecule/ec2_centos7/molecule.yml
+++ b/molecule/ec2_centos7/molecule.yml
@@ -11,6 +11,7 @@ platforms:
     ssh_user: centos
     groups:
       - bootstraps
+      - dcos
   - name: master1-centos7
     image: ami-9887c6e7
     region: us-east-1
@@ -18,6 +19,7 @@ platforms:
     ssh_user: centos
     groups:
       - masters
+      - dcos
   - name: agent1-centos7
     image: ami-9887c6e7
     region: us-east-1
@@ -26,6 +28,7 @@ platforms:
     groups:
       - agents_private
       - agents
+      - dcos
 
 provisioner:
   name: ansible

--- a/molecule/ec2_rhel7/molecule.yml
+++ b/molecule/ec2_rhel7/molecule.yml
@@ -10,12 +10,14 @@ platforms:
     instance_type: m5.large
     groups:
       - bootstraps
+      - dcos
   - name: master1-rhel7
     image: ami-011b3ccf1bd6db744
     region: us-east-1
     instance_type: m5.large
     groups:
       - masters
+      - dcos
   - name: agent1-rhel7
     image: ami-011b3ccf1bd6db744
     region: us-east-1
@@ -23,6 +25,7 @@ platforms:
     groups:
       - agents_private
       - agents
+      - dcos
 
 provisioner:
   name: ansible

--- a/molecule/vagrant_centos7/molecule.yml
+++ b/molecule/vagrant_centos7/molecule.yml
@@ -20,6 +20,7 @@ platforms:
         type: dhcp
     groups:
       - bootstraps
+      - dcos
   - name: master1-centos7
     box: centos/7
     memory: 2048
@@ -30,6 +31,7 @@ platforms:
         type: dhcp
     groups:
       - masters
+      - dcos
   - name: agent1-centos7
     box: centos/7
     memory: 1024
@@ -41,6 +43,7 @@ platforms:
     groups:
       - agents_private
       - agents
+      - dcos
 provisioner:
   name: ansible
   playbooks:

--- a/roles/DCOS.bootstrap/tasks/main.yml
+++ b/roles/DCOS.bootstrap/tasks/main.yml
@@ -115,30 +115,33 @@
     creates: "{{ download_path }}/genconf/serve/dcos_install.sh"
 
 # vvv GENERATE UPGRADE SCRIPTS vvv
-- name: generate DC/OS upgrade files
+- name: "generate DC/OS upgrade files"
   shell: >
-    bash {{ install_file }} --generate-node-upgrade-script {{ dcos['version_to_upgrade_from'] }};
-    mv genconf/serve/upgrade genconf/serve/upgrade_from_{{ dcos['version_to_upgrade_from'] }}
+    bash {{ install_file }} --generate-node-upgrade-script {{ item }};
+    mv genconf/serve/upgrade genconf/serve/upgrade_from_{{ item }}
   args:
     warn: false
     chdir: "{{ download_path }}"
-    creates: "{{ download_path }}/genconf/serve/upgrade_from_{{ dcos['version_to_upgrade_from'] }}/"
-  when: "dcos['version'] is version('1.9', '>=') and dcos['version_to_upgrade_from'] is defined"
+    creates: "{{ download_path }}/genconf/serve/upgrade_from_{{ item }}/"
+  when: "dcos['version'] is version('1.9', '>=')"
+  loop: "{{ groups['dcos'] | map('extract',hostvars,'ansible_local')| list | select('defined') | selectattr('dcos_installation', 'defined') |  map(attribute='dcos_installation') | map(attribute='version') | list | union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}"
 
 - name: get upgrade directory hash
   shell: "ls -td -- */ | head -n 1 | cut -d'/' -f1"
   args:
-    chdir: "{{ download_path }}/genconf/serve/upgrade_from_{{ dcos['version_to_upgrade_from'] }}"
+    chdir: "{{ download_path }}/genconf/serve/upgrade_from_{{ item }}"
   changed_when: false
   register: upgrade_dir_hash
-  when: "dcos['version'] is version('1.9', '>=') and dcos['version_to_upgrade_from'] is defined"
+  when: "dcos['version'] is version('1.9', '>=')"
+  loop: "{{ groups['dcos'] | map('extract',hostvars,'ansible_local')| list | select('defined') | selectattr('dcos_installation', 'defined') |  map(attribute='dcos_installation') | map(attribute='version') | list | union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}"
 
 - name: create latest/ symlink for upgrade.sh
   file:
-    path: "{{ download_path }}/genconf/serve/upgrade_from_{{ dcos['version_to_upgrade_from'] }}/latest"
-    src:  "{{ upgrade_dir_hash.stdout }}"
+    path: "{{ download_path }}/genconf/serve/upgrade_from_{{ item.item }}/latest"
+    src:  "{{ item.stdout }}"
     state: link
-  when: " dcos['version'] is version('1.9', '>=') and dcos['version_to_upgrade_from'] is defined"
+  when: "dcos['version'] is version('1.9', '>=')"
+  loop: "{{upgrade_dir_hash.results}}"
 
 # vvv serve files via http vvv
 

--- a/roles/DCOS.bootstrap/tasks/main.yml
+++ b/roles/DCOS.bootstrap/tasks/main.yml
@@ -124,7 +124,7 @@
     chdir: "{{ download_path }}"
     creates: "{{ download_path }}/genconf/serve/upgrade_from_{{ item }}/"
   when: "dcos['version'] is version('1.9', '>=')"
-  loop: "{{ groups['dcos'] | map('extract',hostvars,'ansible_local')| list | select('defined') | selectattr('dcos_installation', 'defined') |  map(attribute='dcos_installation') | map(attribute='version') | list | union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}"
+  loop: "{{ groups['dcos'] | default([]) | map('extract',hostvars,'ansible_local')| list | select('defined') | selectattr('dcos_installation', 'defined') | map(attribute='dcos_installation') | map(attribute='version') | list | union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}"
 
 - name: get upgrade directory hash
   shell: "ls -td -- */ | head -n 1 | cut -d'/' -f1"
@@ -133,7 +133,7 @@
   changed_when: false
   register: upgrade_dir_hash
   when: "dcos['version'] is version('1.9', '>=')"
-  loop: "{{ groups['dcos'] | map('extract',hostvars,'ansible_local')| list | select('defined') | selectattr('dcos_installation', 'defined') |  map(attribute='dcos_installation') | map(attribute='version') | list | union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}"
+  loop: "{{ groups['dcos'] | default([]) | map('extract',hostvars,'ansible_local')| list | select('defined') | selectattr('dcos_installation', 'defined') | map(attribute='dcos_installation') | map(attribute='version') | list | union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}"
 
 - name: create latest/ symlink for upgrade.sh
   file:

--- a/roles/DCOS.bootstrap/tasks/main.yml
+++ b/roles/DCOS.bootstrap/tasks/main.yml
@@ -19,7 +19,7 @@
         }}
   changed_when: false
 
-- name: double check the prefix/cluster name and version
+- name: Double check the prefix/cluster name and version
   pause:
     prompt: |
         Please double check the prefix/cluster name and version of this cluster:
@@ -59,12 +59,12 @@
      download_path: "{{ download_base_dir }}/{{ dcos_version_specifier }}"
      install_file: "{{ dcos['download']|basename }}"
 
-- name: "create install directory/genconf"
+- name: Ceate install directory/genconf
   file: path={{ download_path }}/genconf state=directory mode=0755
 
 #  vvv DOWNLOAD vvv
 
-- name: download installation file
+- name: Download installation file
   get_url:
     url: "{{ dcos['download'] }}"
     dest: "{{ download_path }}/{{ install_file }}"
@@ -108,14 +108,14 @@
 
 # vvv GENERATE INSTALLER vvv
 
-- name: generate DC/OS bootstrap files
+- name: Generate DC/OS bootstrap files
   command: "bash {{ install_file }}"
   args:
     chdir: "{{ download_path }}"
     creates: "{{ download_path }}/genconf/serve/dcos_install.sh"
 
 # vvv GENERATE UPGRADE SCRIPTS vvv
-- name: "generate DC/OS upgrade files"
+- name: Generate DC/OS upgrade files
   shell: >
     bash {{ install_file }} --generate-node-upgrade-script {{ item }};
     mv genconf/serve/upgrade genconf/serve/upgrade_from_{{ item }}
@@ -124,18 +124,26 @@
     chdir: "{{ download_path }}"
     creates: "{{ download_path }}/genconf/serve/upgrade_from_{{ item }}/"
   when: "dcos['version'] is version('1.9', '>=')"
-  loop: "{{ groups['dcos'] | default([]) | map('extract',hostvars,'ansible_local')| list | select('defined') | selectattr('dcos_installation', 'defined') | map(attribute='dcos_installation') | map(attribute='version') | list | union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}"
+  loop: >
+    {{ groups['dcos'] | default([]) | map('extract',hostvars,'ansible_local')| list |
+     select('defined') | selectattr('dcos_installation', 'defined') |
+     map(attribute='dcos_installation') | map(attribute='version') | list |
+     union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}
 
-- name: get upgrade directory hash
+- name: Get upgrade directory hash
   shell: "ls -td -- */ | head -n 1 | cut -d'/' -f1"
   args:
     chdir: "{{ download_path }}/genconf/serve/upgrade_from_{{ item }}"
   changed_when: false
   register: upgrade_dir_hash
   when: "dcos['version'] is version('1.9', '>=')"
-  loop: "{{ groups['dcos'] | default([]) | map('extract',hostvars,'ansible_local')| list | select('defined') | selectattr('dcos_installation', 'defined') | map(attribute='dcos_installation') | map(attribute='version') | list | union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}"
+  loop: >
+    {{ groups['dcos'] | default([]) | map('extract',hostvars,'ansible_local')| list |
+     select('defined') | selectattr('dcos_installation', 'defined') |
+     map(attribute='dcos_installation') | map(attribute='version') | list |
+     union([dcos['version_to_upgrade_from'] | default(dcos['version']) ]) | unique }}
 
-- name: create latest/ symlink for upgrade.sh
+- name: Create latest/ symlink for upgrade.sh
   file:
     path: "{{ download_path }}/genconf/serve/upgrade_from_{{ item.item }}/latest"
     src:  "{{ item.stdout }}"
@@ -145,7 +153,7 @@
 
 # vvv serve files via http vvv
 
-- name: serve bootstrap files via dockerized httpd
+- name: Serve bootstrap files via dockerized httpd
   docker_container:
     name: bootstrapnginx
     image: nginx


### PR DESCRIPTION
This is useful for larger cluster which are not necessarily on the
version of DC/OS. Also supports 'rolling upgrades' across multiple
version by using Ansible node filter mechanisms.

The prior mandatory parameter `dcos['version_to_upgrade_from']` is now optional. It can be used to specify an (additional) version to generate upgrade scripts _from_. A compacted, unified list of version is collected by using remote facts of all nodes for their current DC/OS version.

**Example:**
Having a cluster with various versions of DC/OS on its agent nodes, such as:
```
$ ansible agents -b -a 'grep -e DCOS_IMAGE_COMMIT -e VERSION /opt/mesosphere/environment'
agent1-testcluster112 | CHANGED | rc=0 >>
DCOS_VERSION=1.12.2
DCOS_IMAGE_COMMIT=ed29688084953193ebb3893765f76e98d6d2533c

agent2-testcluster112 | CHANGED | rc=0 >>
DCOS_VERSION=1.12.1
DCOS_IMAGE_COMMIT=aad01aaa24f90fd83b626acad5069e8328bbcac9

agent3-testcluster112 | CHANGED | rc=0 >>
DCOS_VERSION=1.12.0
DCOS_IMAGE_COMMIT=6156e8f5cb2ad123aa25d116795867c49619be72
```

Running the example `dcos.yml` playbook with these group_vars:
```
dcos:
  download: "https://downloads.dcos.io/dcos/stable/1.12.2/dcos_generate_config.sh"
  version: "1.12.2"
[...]
```

will result in generating three distinct `dcos_node_upgrade.sh` scripts:
* 1.12.0 -> 1.12.2
* 1.12.1 -> 1.12.2
* 1.12.2 -> 1.12.2 (for same version config updates)

Later on the playbook run, each node will pick up the respective script for its currently installed version.
```
$ ansible agents -b -a 'grep -e DCOS_IMAGE_COMMIT -e VERSION /opt/mesosphere/environment'
agent1-testcluster112 | CHANGED | rc=0 >>
DCOS_VERSION=1.12.2
DCOS_IMAGE_COMMIT=ed29688084953193ebb3893765f76e98d6d2533c

agent2-testcluster112 | CHANGED | rc=0 >>
DCOS_VERSION=1.12.2
DCOS_IMAGE_COMMIT=ed29688084953193ebb3893765f76e98d6d2533c

agent3-testcluster112 | CHANGED | rc=0 >>
DCOS_VERSION=1.12.2
DCOS_IMAGE_COMMIT=ed29688084953193ebb3893765f76e98d6d2533c
```
