### PR TITLE
small fix in a lint error 

### DIFF
--- a/roles/DCOS.agent/tasks/main.yml
+++ b/roles/DCOS.agent/tasks/main.yml
@@ -44,5 +44,5 @@
 # or the installed 'image_commit' != the one specified for this installation.
 - import_tasks: dcos_upgrade.yml
   when:
-    - ansible_local is defined and ansible_local.dcos_installation is defined 
+    - ansible_local is defined and ansible_local.dcos_installation is defined
     - (ansible_local.dcos_installation['version'] != dcos['version']) or (dcos['image_commit'] is defined and ansible_local.dcos_installation['dcos-image-commit'] != dcos['image_commit']) or latest_dcos_config_setup_is_installed.rc != 0


### PR DESCRIPTION
Small fix in a lint error exposed from molecule test. Space at the end of line in DCOS.agent/tasks/main.yml.