### PR TITLE
workaround multi-line issue with _contents in dcos-config

### DIFF
--- a/roles/DCOS.bootstrap/defaults/main.yml
+++ b/roles/DCOS.bootstrap/defaults/main.yml
@@ -5,7 +5,7 @@ bootstrap_port: 8080
 s3_prefix: "ansible-dcos-exhibitor"
 
 customer_key: "00000000-0000-0000-0000-000000000000"
-
+dcos_config: {}
 ip_detect: eth0
 resolvers: |
   - 8.8.4.4

--- a/roles/DCOS.bootstrap/tasks/main.yml
+++ b/roles/DCOS.bootstrap/tasks/main.yml
@@ -129,7 +129,6 @@
     dcos_config: "{{ dcos_config | combine({item.key: item.value}) }}"
   when: "item.key not in ['ip_detect_contents','ip_detect_public_contents','fault_domain_detect_contents']"
   with_dict: "{{ dcos['config'] }}"
-  notify: trigger_new_config
 
 - name: Generate DC/OS configuration
   template:

--- a/roles/DCOS.bootstrap/tasks/main.yml
+++ b/roles/DCOS.bootstrap/tasks/main.yml
@@ -96,6 +96,41 @@
   when: "dcos.config.fault_domain_detect_contents is not defined"
   notify: trigger_new_config
 
+# vvv FIXME: workaround for bad multi-line handling in DC/OS config vvv
+
+- name: "Generate IP detection script from ip_detect_contents"
+  copy:
+    dest: "{{ download_path }}/genconf/ip-detect"
+    mode: 0644
+    content: "{{ dcos.config.ip_detect_contents }}"
+  when: "dcos.config.ip_detect_contents is defined"
+  notify: trigger_new_config
+
+- name: "Generate IP detection script from ip_detect_public_contents"
+  copy:
+    dest: "{{ download_path }}/genconf/ip-detect-public"
+    mode: 0644
+    content: "{{ dcos.config.ip_detect_public_contents }}"
+  when: "dcos.config.ip_detect_public_contents is defined"
+  notify: trigger_new_config
+
+- name: "Generate IP detection script from fault_domain_detect_contents"
+  copy:
+    dest: "{{ download_path }}/genconf/fault-domain-detect"
+    mode: 0644
+    content: "{{ dcos.config.fault_domain_detect_contents }}"
+  when: "dcos.config.fault_domain_detect_contents is defined"
+  notify: trigger_new_config
+
+# vvv filter and generate config vvv
+
+- name: Filter Config. Get rid of ip_detect_contents,ip_detect_contents and fault_domain_detect_contents
+  set_fact:
+    dcos_config: "{{ dcos_config | combine({item.key: item.value}) }}"
+  when: "item.key not in ['ip_detect_contents','ip_detect_public_contents','fault_domain_detect_contents']"
+  with_dict: "{{ dcos['config'] }}"
+  notify: trigger_new_config
+
 - name: Generate DC/OS configuration
   template:
     src: "config.yaml.j2"

--- a/roles/DCOS.bootstrap/templates/config.yaml.j2
+++ b/roles/DCOS.bootstrap/templates/config.yaml.j2
@@ -1,1 +1,1 @@
-{{ dcos['config'] | combine({'bootstrap_url': dcos['config']['bootstrap_url']+'/'+dcos_version_specifier+'/genconf/serve' }) | to_yaml }}
+{{ dcos_config | combine({'bootstrap_url': dcos_config['bootstrap_url']+'/'+dcos_version_specifier+'/genconf/serve' }) | to_yaml }}


### PR DESCRIPTION
Found issues when adding multi-line script into e.g. `ip_detect_public_contents`. With this patch we read the content and write it into a file. So DC/OS can use it 