### PR TITLE
wait for hosts become available.

### DIFF
--- a/dcos.yml
+++ b/dcos.yml
@@ -1,4 +1,12 @@
 ---
+- name: Wait for instances to become reachable
+  hosts: all
+  tasks:
+    - name: Wait for instances to become reachable
+      wait_for_connection:
+        sleep: 10
+        timeout: 120
+
 - name: Collect DC/OS versions
   hosts: all
   tasks:


### PR DESCRIPTION
especially when integrated into terraform ansible might get invoked before new instances finished their boot and are reachable via SSH. This patch lets ansible wait for the hosts become available