### PR TITLE
Bugfix/selinux enforcing centos

### DIFF
--- a/roles/DCOS.requirements/tasks/main.yml
+++ b/roles/DCOS.requirements/tasks/main.yml
@@ -23,6 +23,24 @@
     enabled: false
   when: "'dnsmasq.service' in ansible_facts.services"
 
+- name: "linux kernel activate bridge module ip4 (CentOS systems)"
+  sysctl:
+    name: net.bridge.bridge-nf-call-iptables
+    value: 1
+    state: present
+  when: 
+    - selinux_mode == 'enforcing'
+    - ansible_distribution == 'CentOS'
+
+- name: "linux kernel activate bridge module ip6 (CentOS systems)"
+  sysctl:
+    name: net.bridge.bridge-nf-call-ip6tables
+    value: 1
+    state: present
+  when: 
+    - selinux_mode == 'enforcing'
+    - ansible_distribution == 'CentOS'
+
 - name: "Docker CE (stable) repository (Only non-EL systems)"
   yum_repository:
     name: docker-ce

--- a/roles/DCOS.requirements/tasks/main.yml
+++ b/roles/DCOS.requirements/tasks/main.yml
@@ -23,22 +23,20 @@
     enabled: false
   when: "'dnsmasq.service' in ansible_facts.services"
 
-- name: "linux kernel activate bridge module ip4 (CentOS systems)"
+- name: "linux kernel activate bridge module ip4 (CentOS+selinux systems)"
   sysctl:
     name: net.bridge.bridge-nf-call-iptables
     value: 1
     state: present
   when: 
-    - selinux_mode == 'enforcing'
     - ansible_distribution == 'CentOS'
 
-- name: "linux kernel activate bridge module ip6 (CentOS systems)"
+- name: "linux kernel activate bridge module ip6 (CentOS+selinux systems)"
   sysctl:
     name: net.bridge.bridge-nf-call-ip6tables
     value: 1
     state: present
   when: 
-    - selinux_mode == 'enforcing'
     - ansible_distribution == 'CentOS'
 
 - name: "Docker CE (stable) repository (Only non-EL systems)"


### PR DESCRIPTION
Hi,
Thanks for this useful tool.

I am performing some tests for on premise deployment.
Currently I spawn Centos7 VM in a virtualbox.
If I try with selinux=enforcing, this is not working and I get the error below:
>TASK [DCOS.master : Installation: Run DC/OS master installation] >******************************************************
>fatal: [192.168.56.3]: FAILED! => {"changed": true, "cmd": "set -o pipefail; bash >/tmp/dcos/1.12.0/dcos_install.sh master | systemd-cat -t dcos-install", "delta": "0:00:00.252115", "end": "2019-03-25 10:01:22.825347", "msg": "non-zero return code", "rc": 1, "start": "2019-03-25 10:01:22.573232", "stderr": "WARNING: bridge-nf-call-iptables is disabled\nWARNING: bridge-nf-call-ip6tables is disabled", "stderr_lines": ["WARNING: bridge-nf-call-iptables is disabled", "WARNING: bridge-nf-call-ip6tables is disabled"], "stdout": "", "stdout_lines": []}

The sysctl adjustement enclosed in this pull request enable to solve this issue.

I did not manage to apply them only when `selinux_mode==enforcing`, so they are applied to all centos systems.

Regards
Julien 



