### PR TITLE
prereqs: do not attempt to install docker when its already installed with dcos-ansible

### DIFF
--- a/roles/DCOS.requirements/tasks/main.yml
+++ b/roles/DCOS.requirements/tasks/main.yml
@@ -23,6 +23,14 @@
     enabled: false
   when: "'dnsmasq.service' in ansible_facts.services"
 
+- name: Check if docker is already installed
+  yum:
+    list:
+      - docker
+      - docker-ce
+  # If not installed yum_list.results[*].yumstate != installed
+  register: yum_list
+
 - name: "Docker CE (stable) repository (Only non-EL systems)"
   yum_repository:
     name: docker-ce
@@ -31,7 +39,7 @@
     enabled: yes
     gpgcheck: yes
     gpgkey: https://download.docker.com/linux/centos/gpg
-  when: ansible_distribution == 'CentOS'
+  when: ansible_distribution == 'CentOS' and yum_list.results | selectattr("yumstate", "match", "installed") | list | length == 0
 
 - block:
   - name: "Finding RHEL extras repository name (Only EL systems)"
@@ -40,6 +48,7 @@
     register: rhel_exras_repo_name
     changed_when: false
     when: ansible_distribution == 'RedHat'
+
   - name: "Docker installed"
     yum:
       name: "{{ dcos_docker_pkg_name }}"
@@ -59,7 +68,7 @@
     - name: Output
       fail:
         msg: "ABORTING! Could not install '{{ dcos_docker_pkg_name }}'."
-      when: ansible_distribution != 'RedHat'
+      when: ansible_distribution != 'RedHat' and yum_list.results | selectattr("yumstate", "match", "installed") | list | length == 0
 
 - name: "Docker running (Only on some platforms)"
   systemd:


### PR DESCRIPTION
Without this change, this will attempt to install docker. This is to not fail if docker already exist. i

A better longer optimization I suggest here is that we should look to see if we can conditionally perform prereq matching with dcos_version that is based on the supported matrix here: https://docs.mesosphere.com/version-policy/

This change should be reasonable for the time being.

### After: 

```
TASK [DCOS.requirements : Finding RHEL extras repository name (Only EL systems)] ********************************************
skipping: [54.188.208.81]
skipping: [54.188.175.78]
skipping: [54.212.46.61]
skipping: [35.166.83.77]
skipping: [54.70.0.23]
skipping: [18.237.58.142]
skipping: [54.202.19.56]

TASK [DCOS.requirements : Docker installed] *********************************************************************************
changed: [18.237.58.142]
changed: [54.212.46.61]
changed: [54.188.175.78]
changed: [35.166.83.77]
changed: [54.70.0.23]
changed: [54.188.208.81]
changed: [54.202.19.56]

TASK [DCOS.requirements : Docker running (Only on some platforms)] **********************************************************
changed: [54.188.175.78]
changed: [54.188.208.81]
changed: [18.237.58.142]
changed: [54.212.46.61]
changed: [54.70.0.23]
changed: [35.166.83.77]
changed: [54.202.19.56]
```

### Before

```
TASK [DCOS.requirements : Docker installed] 
FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
fatal: [34.212.177.54]: FAILED! => {"attempts": 3, "changed": false, "msg": "Error: docker-ce-cli conflicts with 2:docker-1.13.1-94.gitb2f74b2.el7.centos.x86_64\nError: docker-ce conflicts with 2:docker-1.13.1-94.gitb2f74b2.el7.centos.x86_64\n", "rc": 1, "results": ["Loaded plugins: fastestmirror\nLoading mirror speeds from cached hostfile\n * base: centos.s.uw.edu\n * extrfatal: [34.212.177.54]: FAILED! => {"attemp                                           FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
fatal: [34.212.177.54]: FAILED! => {"attempts": 3, "changed": false, "msg": "Error: docker-ce-cli conflicts with 2:docker-1.13.1-94.gitb2f74b2.el7.centos.x86_64\nError: docker-ce conflicts with 2:docker-1.13.1-94.gitb2f74b2.el7.centos.x86_64\n", "rc": 1, "results": ["Loaded plugins: fastestmirror\nLoading mirror speeds from cached hostfile\n * base: centos.s.uw.edu\n * extrfatal: [34.212.177.54]: FAILED! => {"attempts": 3, "Refatal: [34.212.177.54]: FAILED! => {"attempt                                           FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (2 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
FAILED - RETRYING: Docker installed (1 retries left).
```