### PR TITLE
initial GPU role. Supports NVIDIA and CentOS7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.7-slim
 RUN apt update && apt install -y --no-install-recommends openssh-client && rm -rf /var/lib/apt/lists/*
-RUN pip install ansible==2.7.6
+RUN pip install ansible==2.7.8
 COPY dcos.yml /dcos_playbook.yml
 COPY roles /roles
 COPY ansible.cfg /ansible.cfg
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim
 RUN apt update && apt install -y --no-install-recommends openssh-client && rm -rf /var/lib/apt/lists/*
-RUN pip install ansible==2.7.8
+RUN pip install ansible==2.7.8 jmespath
 COPY dcos.yml /dcos_playbook.yml
 COPY roles /roles
 COPY ansible.cfg /ansible.cfg

--- a/dcos.yml
+++ b/dcos.yml
@@ -21,6 +21,8 @@
   tasks:
     - include_role:
         name: DCOS.requirements
+    - include_role:
+        name: DCOS.gpu
 
 - name: "Setup and configure BOOTSTRAP nodes"
   hosts: bootstraps

--- a/inventory.example
+++ b/inventory.example
@@ -16,6 +16,7 @@ mountvolumeagent1-dcos112s.example.com
 remoteagent1-dcos112s.example.com
 remoteagent2-dcos112s.example.com
 remoteagent3-dcos112s.example.com
+gpuagent1-dcos112s.example.com
 
 [agents_public]
 publicagent1-dcos112s.example.com

--- a/molecule/ec2_centos7_gpu/converge.yml
+++ b/molecule/ec2_centos7_gpu/converge.yml
@@ -1,0 +1,13 @@
+---
+- name: DC/OS Requirements
+  hosts: all
+  become: true
+  tasks:
+    - include_role:
+        name: DCOS.requirements
+- name: DC/OS Requirements
+  hosts: agents
+  become: true
+  tasks:
+    - include_role:
+        name: DCOS.gpu

--- a/molecule/ec2_centos7_gpu/molecule.yml
+++ b/molecule/ec2_centos7_gpu/molecule.yml
@@ -1,0 +1,55 @@
+---
+scenario:
+  name: ec2_centos7_gpu
+driver:
+  name: ec2
+platforms:
+  # - name: gputestagent-centos7.5
+  #   image: ami-9887c6e7
+  #   region: us-east-1
+  #   instance_type: p2.xlarge
+  #   ssh_user: centos
+  #   groups:
+  #     - agents
+  #     - dcos
+  # - name: gputestagent-centos7.4
+  #   image: ami-4bf3d731
+  #   region: us-east-1
+  #   instance_type: g3.4xlarge
+  #   ssh_user: centos
+  #   groups:
+  #     - agents
+  #     - dcos
+  - name: gputestagent-centos7.6
+    image: ami-02eac2c0129f6376b
+    region: us-east-1
+    instance_type: p2.xlarge
+    ssh_user: centos
+    groups:
+      - agents
+      - dcos
+
+provisioner:
+  name: ansible
+  log: true
+  playbooks:
+    ec2:
+      create: ../ec2/create.yml
+      destroy: ../ec2/destroy.yml
+    converge: ./converge.yml
+    # prepare: ./converge.yml
+  config_options:
+    defaults:
+      hash_behaviour: merge
+  env:
+    ANSIBLE_ROLES_PATH: "../../roles/"
+  inventory:
+    links:
+      group_vars: ../../group_vars/
+  lint:
+    name: ansible-lint
+    enabled: True
+lint:
+  name: yamllint
+  options:
+    config-file: .yamllint.yml

--- a/molecule/ec2_centos7_gpu/molecule.yml
+++ b/molecule/ec2_centos7_gpu/molecule.yml
@@ -4,26 +4,39 @@ scenario:
 driver:
   name: ec2
 platforms:
-  # - name: gputestagent-centos7.5
-  #   image: ami-9887c6e7
-  #   region: us-east-1
-  #   instance_type: p2.xlarge
-  #   ssh_user: centos
-  #   groups:
-  #     - agents
-  #     - dcos
-  # - name: gputestagent-centos7.4
-  #   image: ami-4bf3d731
-  #   region: us-east-1
-  #   instance_type: g3.4xlarge
-  #   ssh_user: centos
-  #   groups:
-  #     - agents
-  #     - dcos
+  # uses vault
+  - name: gputestagent-centos7.5
+    image: ami-9887c6e7
+    region: us-east-1
+    instance_type: p2.xlarge
+    ssh_user: centos
+    groups:
+      - agents
+      - dcos
+  # current version
   - name: gputestagent-centos7.6
     image: ami-02eac2c0129f6376b
     region: us-east-1
     instance_type: p2.xlarge
+    ssh_user: centos
+    groups:
+      - agents
+      - dcos
+  # Tesla V100
+  - name: gputestagent-centosV100
+    # centos7.6 ami-02eac2c0129f6376b freezes on boot on p3 instances
+    image: ami-9887c6e7
+    region: us-east-1
+    instance_type: p3.2xlarge
+    ssh_user: centos
+    groups:
+      - agents
+      - dcos
+  # Tesla M60
+  - name: gputestagent-centosM60
+    image: ami-02eac2c0129f6376b
+    region: us-east-1
+    instance_type: g3.4xlarge
     ssh_user: centos
     groups:
       - agents

--- a/molecule/ec2_centos7_gpu/molecule.yml
+++ b/molecule/ec2_centos7_gpu/molecule.yml
@@ -41,6 +41,24 @@ platforms:
     groups:
       - agents
       - dcos
+  # RHEL 7.6 / current version
+  - name: gputestagent-rhel7.6M60
+    image: ami-000db10762d0c4c05
+    region: us-east-1
+    instance_type: g3.4xlarge
+    ssh_user: ec2-user
+    groups:
+      - agents
+      - dcos
+  # RHEL 7.5 / previous version
+  - name: gputestagent-rhel7.5M60
+    image: ami-6871a115
+    region: us-east-1
+    instance_type: g3.4xlarge
+    ssh_user: ec2-user
+    groups:
+      - agents
+      - dcos
 
 provisioner:
   name: ansible

--- a/molecule/ec2_centos7_gpu/molecule.yml
+++ b/molecule/ec2_centos7_gpu/molecule.yml
@@ -10,18 +10,12 @@ platforms:
     region: us-east-1
     instance_type: p2.xlarge
     ssh_user: centos
-    groups:
-      - agents
-      - dcos
   # current version
   - name: gputestagent-centos7.6
     image: ami-02eac2c0129f6376b
     region: us-east-1
     instance_type: p2.xlarge
     ssh_user: centos
-    groups:
-      - agents
-      - dcos
   # Tesla V100
   - name: gputestagent-centosV100
     # centos7.6 ami-02eac2c0129f6376b freezes on boot on p3 instances
@@ -29,36 +23,24 @@ platforms:
     region: us-east-1
     instance_type: p3.2xlarge
     ssh_user: centos
-    groups:
-      - agents
-      - dcos
   # Tesla M60
   - name: gputestagent-centosM60
     image: ami-02eac2c0129f6376b
     region: us-east-1
     instance_type: g3.4xlarge
     ssh_user: centos
-    groups:
-      - agents
-      - dcos
   # RHEL 7.6 / current version
   - name: gputestagent-rhel7.6M60
     image: ami-000db10762d0c4c05
     region: us-east-1
     instance_type: g3.4xlarge
     ssh_user: ec2-user
-    groups:
-      - agents
-      - dcos
   # RHEL 7.5 / previous version
   - name: gputestagent-rhel7.5M60
     image: ami-6871a115
     region: us-east-1
     instance_type: g3.4xlarge
     ssh_user: ec2-user
-    groups:
-      - agents
-      - dcos
 
 provisioner:
   name: ansible
@@ -67,8 +49,7 @@ provisioner:
     ec2:
       create: ../ec2/create.yml
       destroy: ../ec2/destroy.yml
-    converge: ./converge.yml
-    # prepare: ./converge.yml
+    converge: ../../dcos.yml
   config_options:
     defaults:
       hash_behaviour: merge

--- a/molecule/ec2_centos7_gpu/tests/test_default.py
+++ b/molecule/ec2_centos7_gpu/tests/test_default.py
@@ -1,0 +1,11 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_nvidia_smi(host):
+    cmd = host.run("sudo nvidia-smi -L")
+    assert 'GPU 0' in cmd.stdout

--- a/roles/DCOS.gpu/defaults/main.yml
+++ b/roles/DCOS.gpu/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+vault_repo_baseurl: "http://vault.centos.org/{{ os_release_file['content'] |b64decode | regex_search('\\d+\\.\\d+\\.\\d+') }}/os/$basearch/"
+nvidia_repo_rpm: https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-10.1.168-1.x86_64.rpm
+
+nvidia_repo_baseurl: http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64
+nvidia_repo_gpgkey: http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/7fa2af80.pub
+
+rhel7_vulkan_repo_baseurl: http://mirror.centos.org/centos/7/os/$basearch/
+rhel7_vulkan_repo_gpgkey: http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/7fa2af80.pub

--- a/roles/DCOS.gpu/defaults/main.yml
+++ b/roles/DCOS.gpu/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
+# see man lspci (-d)
+nvidia_device_query:
+  - vendor: "10de"
+    class: "0302"
+  - vendor: "10de"
+    class: "0300"
 vault_repo_baseurl: "http://vault.centos.org/{{ os_release_file['content'] |b64decode | regex_search('\\d+\\.\\d+\\.\\d+') }}/os/$basearch/"
 nvidia_repo_rpm: https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-10.1.168-1.x86_64.rpm
 

--- a/roles/DCOS.gpu/meta/main.yml
+++ b/roles/DCOS.gpu/meta/main.yml
@@ -1,0 +1,20 @@
+---
+dependencies: []
+
+galaxy_info:
+  role_name: DCOS.gpu
+  author: dcos
+  description: Add GPU support for RedHat/CentOS agents. Part of a set of Ansible roles that manage DC/OS on RedHat/CentOS Linux.
+  company: "Mesosphere"
+  license: "Apache 2.0"
+  min_ansible_version: 2.5
+  platforms:
+    - name: EL
+      versions:
+        - 7
+  galaxy_tags:
+    - dcos
+    - mesosphere
+    - cloud
+    - cluster
+    - kubernetes

--- a/roles/DCOS.gpu/tasks/main.yml
+++ b/roles/DCOS.gpu/tasks/main.yml
@@ -4,5 +4,12 @@
     name: pciutils
     state: present
 # only NVIDIA for now
-- name: "NVIDIA Gpu"
+- name: Detect NVIDIA devices
+  command: "lspci -d {{ item.vendor|default('') }}:{{ item.device|default('') }}:{{ item.class|default('') }} -nn -mm"
+  register: lspci_nvidia
+  with_items: "{{ nvidia_device_query }}"
+  changed_when: false
+
+- name: "NVIDIA GPU detected"
   include_tasks: nvidia-gpu.yml
+  when: lspci_nvidia|json_query('results[*].stdout_lines')|flatten|length > 0

--- a/roles/DCOS.gpu/tasks/main.yml
+++ b/roles/DCOS.gpu/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Ensure pciutils installed
+  yum:
+    name: pciutils
+    state: present
+# only NVIDIA for now
+- name: "NVIDIA Gpu"
+  include_tasks: nvidia-gpu.yml

--- a/roles/DCOS.gpu/tasks/nvidia-gpu-CentOS7.yml
+++ b/roles/DCOS.gpu/tasks/nvidia-gpu-CentOS7.yml
@@ -8,9 +8,6 @@
     src: /etc/centos-release
   register: os_release_file
 
-- name: pkgheaders debug
-  debug:
-    msg: "{{ pkgheaders }}"
 # If possible we use headers from main OS repo for this kernel.
 - name: Install Kernel Header and Devel from OS repo for Current Kernel
   yum:
@@ -23,7 +20,7 @@
   yum_repository:
     name: ThisVault
     description: This Vault
-    baseurl: "http://vault.centos.org/{{ os_release_file['content'] |b64decode | regex_search('\\d+\\.\\d+\\.\\d+') }}/os/$basearch/"
+    baseurl: "{{ vault_repo_baseurl }}"
     enabled: false
   when: pkgheaders.results|length == 0
 - name: Install Kernel Headers for Current Kernel
@@ -54,9 +51,13 @@
 
 # Install NVIDIA repository, driver and tools
 - name: Add NVIDIA repository for CUDA drivers and tools
-  yum:
-    name: https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-10.1.168-1.x86_64.rpm
-    state: present
+  yum_repository:
+    name: cuda
+    description: NVIDIA cuda repository
+    enabled: true
+    baseurl: "{{ nvidia_repo_baseurl }}"
+    gpgkey: "{{ nvidia_repo_gpgkey }}"
+    gpgcheck: true
 - name: Install cuda drivers and tools
   yum:
     name:

--- a/roles/DCOS.gpu/tasks/nvidia-gpu-CentOS7.yml
+++ b/roles/DCOS.gpu/tasks/nvidia-gpu-CentOS7.yml
@@ -3,25 +3,29 @@
   yum:
     list: "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
   register: pkgheaders
+- name: get CentOS specific release version
+  slurp:
+    src: /etc/centos-release
+  register: os_release_file
 
+- name: pkgheaders debug
+  debug:
+    msg: "{{ pkgheaders }}"
 # If possible we use headers from main OS repo for this kernel.
-- name: Install Kernel Headers for Current Kernel
+- name: Install Kernel Header and Devel from OS repo for Current Kernel
   yum:
-      name: "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
-  when: pkgheaders|length > 0
-- name: Install Kernel Devel for Current Kernel
-  yum:
-      name: "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel }}"
-  when: pkgheaders|length > 0
-
+      name:
+        - "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
+        - "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel }}"
+  when: pkgheaders.results|length > 0
 # CentOS VAULT - Kernel Headers not available in main OS repo anymore. Use Vault for this release
 - name: ThisVault
   yum_repository:
     name: ThisVault
     description: This Vault
-    baseurl: http://vault.centos.org/{{ hostvars[inventory_hostname].ansible_distribution_version }}/os/$basearch/
+    baseurl: "http://vault.centos.org/{{ os_release_file['content'] |b64decode | regex_search('\\d+\\.\\d+\\.\\d+') }}/os/$basearch/"
     enabled: false
-  when: pkgheaders|length == 0
+  when: pkgheaders.results|length == 0
 - name: Install Kernel Headers for Current Kernel
   yum:
       enablerepo: ThisVault
@@ -31,7 +35,7 @@
   yum:
       enablerepo: ThisVault
       name: "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel | regex_search('\\d+\\.\\d+\\.\\d+-\\d+') }}.el{{ hostvars[inventory_hostname].ansible_distribution_major_version }}"
-  when: pkgheaders|length == 0
+  when: pkgheaders.results|length == 0
 - name: Ensure to link against merged kernel headers
   file:
     dest: "/lib/modules/{{ hostvars[inventory_hostname].ansible_kernel }}/build"
@@ -39,7 +43,14 @@
     force: yes
     state: link
     follow: false
-  when: pkgheaders|length == 0
+  when: pkgheaders.results|length == 0
+
+# ensure nouveau being unloaded
+- name: Ensure nouveau being unloaded
+  modprobe:
+    name: nouveau
+    state: absent
+  changed_when: False
 
 # Install NVIDIA repository, driver and tools
 - name: Add NVIDIA repository for CUDA drivers and tools

--- a/roles/DCOS.gpu/tasks/nvidia-gpu-CentOS7.yml
+++ b/roles/DCOS.gpu/tasks/nvidia-gpu-CentOS7.yml
@@ -1,0 +1,53 @@
+---
+- name: find this kernel headers
+  yum:
+    list: "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
+  register: pkgheaders
+
+# If possible we use headers from main OS repo for this kernel.
+- name: Install Kernel Headers for Current Kernel
+  yum:
+      name: "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
+  when: pkgheaders|length > 0
+- name: Install Kernel Devel for Current Kernel
+  yum:
+      name: "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel }}"
+  when: pkgheaders|length > 0
+
+# CentOS VAULT - Kernel Headers not available in main OS repo anymore. Use Vault for this release
+- name: ThisVault
+  yum_repository:
+    name: ThisVault
+    description: This Vault
+    baseurl: http://vault.centos.org/{{ hostvars[inventory_hostname].ansible_distribution_version }}/os/$basearch/
+    enabled: false
+  when: pkgheaders|length == 0
+- name: Install Kernel Headers for Current Kernel
+  yum:
+      enablerepo: ThisVault
+      name: "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel | regex_search('\\d+\\.\\d+\\.\\d+-\\d+') }}.el{{ hostvars[inventory_hostname].ansible_distribution_major_version }}"
+  when: pkgheaders|length == 0
+- name: Install Kernel Devel for Current Kernel
+  yum:
+      enablerepo: ThisVault
+      name: "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel | regex_search('\\d+\\.\\d+\\.\\d+-\\d+') }}.el{{ hostvars[inventory_hostname].ansible_distribution_major_version }}"
+  when: pkgheaders|length == 0
+- name: Ensure to link against merged kernel headers
+  file:
+    dest: "/lib/modules/{{ hostvars[inventory_hostname].ansible_kernel }}/build"
+    src: "/usr/src/kernels/{{ hostvars[inventory_hostname].ansible_kernel | regex_search('\\d+\\.\\d+\\.\\d+-\\d+') }}.el{{ hostvars[inventory_hostname].ansible_distribution_major_version }}.x86_64/"
+    force: yes
+    state: link
+    follow: false
+  when: pkgheaders|length == 0
+
+# Install NVIDIA repository, driver and tools
+- name: Add NVIDIA repository for CUDA drivers and tools
+  yum:
+    name: https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-10.1.168-1.x86_64.rpm
+    state: present
+- name: Install cuda drivers and tools
+  yum:
+    name:
+      - cuda
+    state: present

--- a/roles/DCOS.gpu/tasks/nvidia-gpu-RHEL7.yml
+++ b/roles/DCOS.gpu/tasks/nvidia-gpu-RHEL7.yml
@@ -1,0 +1,43 @@
+---
+# If possible we use headers from main OS repo for this kernel.
+- name: Install Kernel Header and Devel from OS repo for Current Kernel
+  yum:
+      name:
+        - "kernel-headers-{{ hostvars[inventory_hostname].ansible_kernel }}"
+        - "kernel-devel-{{ hostvars[inventory_hostname].ansible_kernel }}"
+
+# ensure nouveau being unloaded
+- name: Ensure nouveau being unloaded
+  modprobe:
+    name: nouveau
+    state: absent
+  changed_when: False
+
+- name: Use Centos Base Repo for vulkan-filesystem
+  yum_repository:
+    name: vulkanfs-repo
+    description: Workaround repo to get vulkan-filesystem
+    baseurl: "{{ rhel7_vulkan_repo_baseurl }}"
+    gpgkey: "{{ rhel7_vulkan_repo_gpgkey }}"
+    enabled: false
+
+- name: Use vulkan-filesystem from centos
+  yum:
+    name: vulkan-filesystem
+    enablerepo: vulkanfs-repo
+
+# Install NVIDIA repository, driver and tools
+- name: Add NVIDIA repository for CUDA drivers and tools
+  yum_repository:
+    name: cuda
+    description: NVIDIA cuda repository
+    enabled: true
+    baseurl: "{{ nvidia_repo_baseurl }}"
+    gpgkey: "{{ nvidia_repo_gpgkey }}"
+    gpgcheck: true
+- name: Install cuda drivers and tools
+  yum:
+    enablerepo: epel
+    name:
+      - cuda
+    state: present

--- a/roles/DCOS.gpu/tasks/nvidia-gpu.yml
+++ b/roles/DCOS.gpu/tasks/nvidia-gpu.yml
@@ -2,3 +2,6 @@
 - name: "NVIDIA Gpu - CentOS 7"
   include_tasks: nvidia-gpu-CentOS7.yml
   when: ansible_distribution == "CentOS" and ansible_distribution_major_version == '7'
+- name: "NVIDIA Gpu - RHEL 7"
+  include_tasks: nvidia-gpu-RHEL7.yml
+  when: ansible_distribution == 'RedHat' and ansible_distribution_major_version == '7'

--- a/roles/DCOS.gpu/tasks/nvidia-gpu.yml
+++ b/roles/DCOS.gpu/tasks/nvidia-gpu.yml
@@ -1,0 +1,4 @@
+---
+- name: "NVIDIA Gpu - CentOS 7"
+  include_tasks: nvidia-gpu-CentOS7.yml
+  when: ansible_distribution == "CentOS" and ansible_distribution_major_version == '7'

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,4 +4,5 @@ molecule[vagrant]
 boto
 boto3
 ansible-lint==4.1.0
+ansible==2.7.6
 yamllint==1.15.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -4,5 +4,5 @@ molecule[vagrant]
 boto
 boto3
 ansible-lint==4.1.0
-ansible==2.7.6
+ansible==2.7.8
 yamllint==1.15.0


### PR DESCRIPTION
Initial version works with CentOS 7.x and `p2` instances. `p3` and `g3` instances not working. `p3`/Tesla V100 should work as it should be the same driver as `p2` / K80. 

G3 needs a different driver.