### PR TITLE
[WIP] use py27 for ec2 plugins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
       parallel {
         stage('molecule test (ec2_centos7)') {
           agent {
-            label "py36"
+            label "py27"
           }
             steps {
               retry(3) {
@@ -58,7 +58,7 @@ pipeline {
         }
         stage('molecule test (ec2_rhel7)') {
           agent {
-            label "py36"
+            label "py27"
           }
             steps {
               retry(3) {


### PR DESCRIPTION
py36 is probably causing flaky tests as the ec2 plugin works better on py27