### PR TITLE
readd python-pip

### DIFF
--- a/roles/DCOS.bootstrap/tasks/main.yml
+++ b/roles/DCOS.bootstrap/tasks/main.yml
@@ -38,7 +38,7 @@
 
 - name: Install pip to install python-docker
   yum:
-    name: python-pip
+    name: python2-pip
     state: present
   register: dcos_yum_pythonpip_install
   retries: 3


### PR DESCRIPTION
exactly python2-pip, as it is now only present in epel repo we need to activate it here also