### PR TITLE
DCOS_OSS-5338: resolving Jenkins slave spin up issue of killed pull image by mesos-executor

### DIFF
--- a/roles/DCOS.agent_windows/tasks/main.yml
+++ b/roles/DCOS.agent_windows/tasks/main.yml
@@ -39,7 +39,7 @@
   win_nssm:
     name: "{{ mesos_workers.windows.service_name }}"
     application: "{{ mesos_workers.windows.executor }}"
-    app_parameters_free_form: --master="zk://{{ zookeeper }}/mesos" --launcher_dir="{{ mesos_workers.windows.bindir }}" --log_dir="{{ mesos_workers.windows.logdir }}" --appc_store_dir="{{ mesos_workers.windows.imagesdir }}" --work_dir="{{ mesos_workers.windows.workdir }}" --runtime_dir="{{ mesos_workers.windows.workdir }}" --isolation="windows/cpu,windows/mem,filesystem/windows" --containerizers="mesos,docker" --attributes="{{ mesos_workers.windows.attributes }}" --ip={{ inventory_hostname }} --hostname={{ inventory_hostname }} --resources="ports:[{{ resources_ports }}]"
+    app_parameters_free_form: --master="zk://{{ zookeeper }}/mesos" --launcher_dir="{{ mesos_workers.windows.bindir }}" --log_dir="{{ mesos_workers.windows.logdir }}" --appc_store_dir="{{ mesos_workers.windows.imagesdir }}" --work_dir="{{ mesos_workers.windows.workdir }}" --runtime_dir="{{ mesos_workers.windows.workdir }}" --isolation="windows/cpu,windows/mem,filesystem/windows" --containerizers="mesos,docker" --attributes="{{ mesos_workers.windows.attributes }}" --ip={{ inventory_hostname }} --hostname={{ inventory_hostname }} --resources="ports:[{{ resources_ports }}]" --executor_registration_timeout={{ mesos_workers.windows.executor_timeout }} --fetcher_stall_timeout={{ mesos_workers.windows.fetcher_timeout }}
 
 - name: Windows | Set Mesos Agent dependency on Docker service
   win_service:

--- a/roles/DCOS.agent_windows/vars/main.yml
+++ b/roles/DCOS.agent_windows/vars/main.yml
@@ -9,13 +9,15 @@ system_user: "Administrator"
 mesos_workers:
   windows:
     service_name: "mesos-agent"
+    attributes: "os:windows"
     homedir: "C:\\dcos"
     bindir: "C:\\dcos\\mesos-binaries"
     workdir: "C:\\dcos\\work"
     imagesdir: "C:\\dcos\\images"
     logdir: "C:\\dcos\\mesos-logs"
-    attributes: "os:windows"
     executor: "C:\\dcos\\mesos-binaries\\mesos-agent.exe"
+    executor_timeout: 10mins
+    fetcher_timeout: 10mins
 
 # Packages location
 bucket_name: "dcos-win.s3.amazonaws.com"


### PR DESCRIPTION
added fetcher_timeout, executor_timeout so that mesos-agent will wait (10mins, instead of previous 1min) before kill docker fetch process