### PR TITLE
Changed the way how we check cockroach status during upgrade

### DIFF
--- a/roles/DCOS.master/tasks/dcos_upgrade.yml
+++ b/roles/DCOS.master/tasks/dcos_upgrade.yml
@@ -64,9 +64,9 @@
 - name: "Upgrade: Check for CockroachDB replication status (Enterprise only)"
   shell: |
     set -o pipefail
-    /opt/mesosphere/bin/cockroach node status --ranges --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) --format tsv 2>/dev/null | tail -n+2 | head -n-1 | cut -f 10 | uniq
+    /opt/mesosphere/bin/dcos-check-runner check node-poststart cockroachdb_replication
   retries: 12
   delay: 10
   register: cockroachdb_result
-  until: cockroachdb_result.stdout  == '0'
+  until: cockroachdb_result.rc  == 0
   when: dcos['enterprise_dcos']


### PR DESCRIPTION
We have hit an [issue](https://jira.mesosphere.com/browse/DCOS-56384) during upgrade of soak114s cluster with [cockroachdb checks](https://github.com/dcos/dcos-ansible/blob/master/roles/DCOS.master/tasks/dcos_upgrade.yml#L67) as cockroachdb recent version changed it's output by adding a new column with build version. 
 
```
/opt/mesosphere/bin/cockroach node status --ranges --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) --format tsv 2>/dev/null
id      address build   started_at      updated_at      is_available    is_live replicas_leaders        replicas_leaseholders   ranges  ranges_unavailable      ranges_underreplicated
1       172.16.9.1:26257                1970-01-01 00:00:00+00:00       2019-07-11 10:36:41.307531+00:00        true    false   40      40      191     0       0
2       172.16.22.125:26257             1970-01-01 00:00:00+00:00       2019-07-11 10:36:38.199431+00:00        true    false   39      38      191     0       0
3       172.16.26.212:26257             1970-01-01 00:00:00+00:00       2019-07-11 10:36:38.570055+00:00        true    false   41      41      191     0       0
4       172.16.6.44:26257       v2.1.7  2019-07-11 10:19:33.902568+00:00        2019-07-11 10:36:39.973026+00:00        true    true    33      33      191     0       0
5       172.16.36.233:26257             1970-01-01 00:00:00+00:00       2019-07-11 10:36:37.294593+00:00        true    false   38      38      191     0       0
```
This makes `/opt/mesosphere/bin/cockroach node status --ranges --certs-dir=/run/dcos/pki/cockroach --host=$(/opt/mesosphere/bin/detect_ip) --format tsv 2>/dev/null | tail -n+2 | head -n-1 | cut -f 10 | uniq` command show wrong result making the upgrade fail, as the output of this command after the upgrade is `total_ranges` but not the `ranges_underreplicated`, as it's supposed to be. 

This PR changes the way how upgrade script checks for `ranges_underreplicated` and uses DC/OS native way of checking by performing `/opt/mesosphere/bin/dcos-check-runner check node-poststart cockroachdb_replication`
