### PR TITLE
setting docker version for Centos7 because its casusing DCOS install failures

### DIFF
--- a/roles/DCOS.requirements/vars/CentOS7.yml
+++ b/roles/DCOS.requirements/vars/CentOS7.yml
@@ -1,4 +1,4 @@
-dcos_docker_pkg_name: docker-ce
+dcos_docker_pkg_name: docker-ce-18.06.2.ce-3.el7
 dcos_prereq_packages:
   - tar
   - xz

--- a/roles/DCOS.requirements/vars/CentOS7.yml
+++ b/roles/DCOS.requirements/vars/CentOS7.yml
@@ -1,4 +1,4 @@
-dcos_docker_pkg_name: docker-ce-18.06.2.ce-3.el7
+dcos_docker_pkg_name: docker-ce-18.09.2
 dcos_prereq_packages:
   - tar
   - xz


### PR DESCRIPTION
```bash
 ./dcos_install.sh master
Starting DC/OS Install Process
Running preflight checks
Checking if DC/OS is already installed: PASS (Not installed)
Checking docker version requirement (>= 1.6): FAIL (0.18.0)
Preflight checks failed. Exiting installation. Please consult product documentation
``` 

Setting Docker Version for Centos 7