### PR TITLE
Jenkinsfile correction and additionals

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,6 +101,9 @@ pipeline {
             GALAXY_API_KEY = credentials('dcos-sre-robot-galaxy-ansible-api-token')
           }
           steps {
+            retry(3) {
+              sh("pip install -r test_requirements.txt")
+            }
             sh("if [ -f ./galaxy.yml ]; then mazer build; fi")
             // sh("for i in ./releases/*; do mazer publish --api-key=${GALAXY_API_KEY} \${i}; done")
           }

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,4 +7,4 @@ hash_behaviour = replace
 [ssh_connection]
 control_path = %(directory)s/%%C
 pipelining = True
-ssh_args = -o PreferredAuthentications=publickey -o ControlMaster=auto -o ControlPersist=5m -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o PasswordAuthentication=no -o ConnectTimeout=320
+ssh_args = -o PreferredAuthentications=publickey -o ControlMaster=auto -o ControlPersist=5m -o IdentitiesOnly=yes -o PasswordAuthentication=no -o ConnectTimeout=320

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,4 +7,4 @@ hash_behaviour = replace
 [ssh_connection]
 control_path = %(directory)s/%%C
 pipelining = True
-ssh_args = -o PreferredAuthentications=publickey -o ControlMaster=auto -o ControlPersist=5m
+ssh_args = -o PreferredAuthentications=publickey -o ControlMaster=auto -o ControlPersist=5m -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o PasswordAuthentication=no -o ConnectTimeout=320

--- a/molecule/ec2/create.yml
+++ b/molecule/ec2/create.yml
@@ -86,7 +86,7 @@
             volume_type: gp2
             delete_on_termination: yes
         instance_tags:
-          Name: "molecule {{ item.name }} {{ lookup('env', 'USER') }}@{{ lookup('env', 'HOSTNAME') }}"
+          Name: "molecule {{ item.name }} {{ lookup('env', 'USER') | default('ci', true) }}@{{ lookup('env', 'HOSTNAME') | default((lookup('env', 'USER') + lookup('pipe', 'date +%Y-%m-%d-%H-%M-%S')) | to_uuid, true) }}"
           instance: "{{ item.name }}"
           molecule_region: "{{ item.region }}"
           molecule_ssh_user: "{{ item.ssh_user | default(ssh_user) }}"


### PR DESCRIPTION
- install requirements in galaxy stage as we cannot bet to be on an already used py36 agent
- be specific with ssh_args in ansible.cfg
- creating a instance name with a UUID if HOSTNAME is not set