### PR TITLE
Replace default('') with default(omit) jinja filter in docker install task

### DIFF
--- a/roles/dcos_requirements/tasks/main.yml
+++ b/roles/dcos_requirements/tasks/main.yml
@@ -134,7 +134,7 @@
     yum:
       name: "{{ dcos_docker_pkg_name }}"
       update_cache: true
-      enablerepo: "{{ rhel_exras_repo_name.stdout | default('') }}"
+      enablerepo: "{{ rhel_exras_repo_name.stdout | default(omit) }}"
       state: present
     register: dcos_yum_docker_install
     until: dcos_yum_docker_install is success


### PR DESCRIPTION
In ansible <2.8 ,the default('') jinja filter doesn´t seem to work (on Centos 7/RHEL 7 environments). We have checked the default(omit) jinja filter works in such cases. 