### PR TITLE
preinstall containerd.io to avoid kmem bug on >=containerd.io-1.2.10

### DIFF
--- a/roles/dcos_requirements/tasks/main.yml
+++ b/roles/dcos_requirements/tasks/main.yml
@@ -122,6 +122,13 @@
     gpgkey: https://download.docker.com/linux/centos/gpg
   when: ansible_distribution == 'CentOS' and yum_list_docker.results | selectattr("yumstate", "match", "installed") | list | length == 0
 
+- name: "Preinstall containerd.io for docker-ce on CentOS preventing kmem bug"
+  yum:
+    name: "{{ dcos_containerd_pkg_name }}"
+    update_cache: true
+    state: present
+  when: ansible_distribution == 'CentOS' and yum_list_docker.results | selectattr("yumstate", "match", "installed") | list | length == 0
+
 - block:
   - name: "Finding RHEL extras repository name (Only EL systems)"
     shell: |

--- a/roles/dcos_requirements/vars/CentOS7.yml
+++ b/roles/dcos_requirements/vars/CentOS7.yml
@@ -2,6 +2,7 @@ dcos_timesync: True
 cloud_time_sync_package: chrony
 onprem_time_sync_package: ntp
 dcos_docker_pkg_name: docker-ce-18.09.2
+dcos_containerd_pkg_name: containerd.io-1.2.6
 dcos_prereq_packages:
   - tar
   - xz


### PR DESCRIPTION
- added preinstall step of containerd.io for CentOS
- added containerd.io package name

newer versions of dockerd will still be supported as yum will update containerd is necessary.

As of today docker-ce has dependency to:
```
  dependency: containerd.io >= 1.2.2-3
   provider: containerd.io.x86_64 1.2.10-3.2.el7
```