### PR TITLE
merge by default. Needed for Universal Installer

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,7 +3,7 @@ inventory = inventory
 host_key_checking = False
 remote_user = centos
 forks = 100
-hash_behaviour = replace
+hash_behaviour = merge
 [ssh_connection]
 control_path = %(directory)s/%%C
 pipelining = True


### PR DESCRIPTION
to support additional ansible config in universal installer we need to hash merge by default