### PR TITLE
DCOS-OSS_5791 [Windows BETA Support] - fixing missing fact dcos_version_specifier

### DIFF
--- a/roles/dcos_agent_windows/tasks/dcos_install.yml
+++ b/roles/dcos_agent_windows/tasks/dcos_install.yml
@@ -5,7 +5,7 @@
 
 - name: Windows Installation | Download dcos_install.ps1
   win_get_url:
-    url: "{{ dcos['config']['bootstrap_url'] }}/{{ dcos['version'] }}/genconf/serve/windows/prerequisites/dcos_install.ps1"
+    url: "{{ dcos['config']['bootstrap_url'] }}/{{ dcos_version_specifier }}/genconf/serve/windows/prerequisites/dcos_install.ps1"
     dest: "{{ base_windows_dir }}\\dcos_install.ps1"
 
 - name: Windows Installation | DC/OS install

--- a/roles/dcos_agent_windows/tasks/main.yml
+++ b/roles/dcos_agent_windows/tasks/main.yml
@@ -1,3 +1,7 @@
+- name: Windows | Defining DC/OS by using 'version' or, more specifically, 'image_commit'
+  set_fact:
+     dcos_version_specifier: "{{ dcos['image_commit'] | default(dcos['version']) }}"
+
 # TO DO: remove when Winpanda is able to create Mesos-DNS by its own
 - name: Windows | Detect network interface with default_gateway set
   set_fact:


### PR DESCRIPTION
@fatz , fixing missing fact dcos_version_specifier in the dcos_agent_windows role. 
Would you be able to re-approve the PR and re-push `mesosphere/dcos-ansible-bundle:windows-beta-support` image? 