### PR TITLE
DCOS_OSS-5851: DC/OS ansible windows role - version checker added

### DIFF
--- a/roles/dcos_agent_windows/handlers/main.yml
+++ b/roles/dcos_agent_windows/handlers/main.yml
@@ -1,4 +1,0 @@
-  - name: Windows | Re-run setup to use custom facts
-  setup: ~
-  fact_path: "{{ base_windows_dir }}\\etc\\dcos-version.json"
-  listen: reload facts

--- a/roles/dcos_agent_windows/handlers/main.yml
+++ b/roles/dcos_agent_windows/handlers/main.yml
@@ -1,0 +1,4 @@
+  - name: Windows | Re-run setup to use custom facts
+  setup: ~
+  fact_path: "{{ base_windows_dir }}\\etc\\dcos-version.json"
+  listen: reload facts

--- a/roles/dcos_agent_windows/tasks/dcos_install.yml
+++ b/roles/dcos_agent_windows/tasks/dcos_install.yml
@@ -12,11 +12,6 @@
   when: (ansible_local is not defined) or (ansible_local.dcos_installation is not defined) or (ansible_local.dcos_installation['dcos-image-commit'] is not defined)
   block:
     - name: Windows Installation | Run DC/OS agent installation
-      win_shell: "{{ base_windows_dir }}\\dcos_install.ps1 '{{ dcos['config']['bootstrap_url'] }}/{{ dcos_version_specifier }}/genconf/serve' '{{ groups['masters'] | join(',') }}'"
-      register: install_shell_result
-
-  always:
-    - name: Windows Installation | Output log into dcos-install.log
-      win_copy:
-        content: "{{ install_shell_result.stdout }}"
-        dest: "{{ base_windows_dir }}\\var\\log\\ansible_playbook_stdout.log"
+      win_shell: "{{ base_windows_dir }}\\dcos_install.ps1 '{{ dcos['config']['bootstrap_url'] }}/{{ dcos_version_specifier }}/genconf/serve' '{{ groups['masters'] | join(',') }}'" >> "{{ base_windows_dir }}\\var\\log\\ansible_playbook_stdout.log"
+      args:
+        creates: "{{ base_windows_dir }}\\var\\log\\ansible_playbook_stdout.log"

--- a/roles/dcos_agent_windows/tasks/dcos_install.yml
+++ b/roles/dcos_agent_windows/tasks/dcos_install.yml
@@ -12,6 +12,20 @@
   when: (ansible_local is not defined) or (ansible_local.dcos_installation is not defined) or (ansible_local.dcos_installation['dcos-image-commit'] is not defined)
   block:
     - name: Windows Installation | Run DC/OS agent installation
-      win_shell: "{{ base_windows_dir }}\\dcos_install.ps1 '{{ dcos['config']['bootstrap_url'] }}/{{ dcos_version_specifier }}/genconf/serve' '{{ groups['masters'] | join(',') }}'" >> "{{ base_windows_dir }}\\var\\log\\ansible_playbook_stdout.log"
-      args:
-        creates: "{{ base_windows_dir }}\\var\\log\\ansible_playbook_stdout.log"
+      win_shell: "{{ base_windows_dir }}\\dcos_install.ps1 '{{ dcos['config']['bootstrap_url'] }}/{{ dcos_version_specifier }}/genconf/serve' '{{ groups['masters'] | join(',') }}'"
+      register: install_shell_stdout
+
+  always:
+    - name: Windows Installation | Output log into ansible_playbook.log
+      win_copy:
+        content: |
+          ================================================
+          Ansible STDOUT:
+          ------------------------------------------------
+          {{ install_shell_stdout.stdout }}
+          ================================================
+          Ansible STDERR:
+          ------------------------------------------------
+          {{ install_shell_stdout.stderr }}
+          ================================================
+        dest: "{{ base_windows_dir }}\\var\\log\\ansible_playbook.log"

--- a/roles/dcos_agent_windows/tasks/main.yml
+++ b/roles/dcos_agent_windows/tasks/main.yml
@@ -7,19 +7,28 @@
     path: "{{ base_windows_dir }}\\etc\\ansible\\facts.d"
     state: directory
 
-- name: Windows | Custom DC/OS facts if
-  win_file:
-    path: "{{ base_windows_dir }}\\etc\\dcos-version.json"
-    state: file
-  register: exists
+- name: Windows | Check for previous intallations
+  win_stat:
+    path: '{{ base_windows_dir }}\etc\dcos-version.json'
+  register: previous_installation
+
+- name: Windows | Create dcos_installation.fact.ps1
+  win_copy:
+    content: get-content {{ base_windows_dir }}\etc\ansible\facts.d\dcos_installation.fact -Raw | ConvertFrom-Json
+    dest: "{{ base_windows_dir }}\\etc\\ansible\\facts.d\\dcos_installation.fact.ps1"
+  when: previous_installation.stat.exists and previous_installation.stat.isreg
 
 - name: Windows | Copy dcos-version.json to fact directory
   win_copy:
     src: "{{ base_windows_dir }}\\etc\\dcos-version.json"
     dest: "{{ base_windows_dir }}\\etc\\ansible\\facts.d\\dcos_installation.fact"
-  when: exists is defined
-  notify: reload facts
-- meta: flush_handlers
+    remote_src: yes
+  when: previous_installation.stat.exists and previous_installation.stat.isreg
+
+- name: Windows | Re-run setup to use custom facts
+  setup:
+    fact_path: "{{ base_windows_dir }}\\etc\\ansible\\facts.d\\dcos_installation.fact.ps1"
+  when: previous_installation.stat.exists and previous_installation.stat.isreg
 
 # TO DO: remove when Winpanda is able to create Mesos-DNS by its own
 - name: Windows | Detect network interface with default_gateway set

--- a/roles/dcos_agent_windows/tasks/main.yml
+++ b/roles/dcos_agent_windows/tasks/main.yml
@@ -2,6 +2,25 @@
   set_fact:
      dcos_version_specifier: "{{ dcos['image_commit'] | default(dcos['version']) }}"
 
+- name: Windows | Create custom fact directory
+  win_file:
+    path: "{{ base_windows_dir }}\\etc\\ansible\\facts.d"
+    state: directory
+
+- name: Windows | Custom DC/OS facts if
+  win_file:
+    path: "{{ base_windows_dir }}\\etc\\dcos-version.json"
+    state: file
+  register: exists
+
+- name: Windows | Copy dcos-version.json to fact directory
+  win_copy:
+    src: "{{ base_windows_dir }}\\etc\\dcos-version.json"
+    dest: "{{ base_windows_dir }}\\etc\\ansible\\facts.d\\dcos_installation.fact"
+  when: exists is defined
+  notify: reload facts
+- meta: flush_handlers
+
 # TO DO: remove when Winpanda is able to create Mesos-DNS by its own
 - name: Windows | Detect network interface with default_gateway set
   set_fact:


### PR DESCRIPTION
Hi @fatz , 
please review the change to Windows agent role. It slightly differs to classical Linux agent, as win_* modules doesn't have sym link creation, reads facts from *.ps1 scripts only - another word they have different simplified implementation. 
However we reaches goal of having version checker and able to determine 2nd installation  by having dcos-version.json file placed into {{ install_dir }}\etc\dcos-version.json 

