### PR TITLE
DCOS_OSS-5851: fix for dcos_install.yml loading condition

### DIFF
--- a/roles/dcos_agent_windows/tasks/main.yml
+++ b/roles/dcos_agent_windows/tasks/main.yml
@@ -49,4 +49,4 @@
 
 # Installation for fresh nodes
 - import_tasks: dcos_install.yml
-  when: (ansible_local is not defined) or (ansible_local.dcos_installation is not defined) or (ansible_local.dcos_installation['dcos-image-commit'] is not defined)
+  when: ( hostvars[inventory_hostname]['ansible_dcos_installation'] is not defined ) or ( hostvars[inventory_hostname]['ansible_dcos_installation']['dcos-image-commit'] is not defined )


### PR DESCRIPTION
@fatz, 
the setup module for Windows is designed not the way it works for Linux. Ansible_local doesn't contain ansible_dcos_installation facts. However  hostvars[inventory_hostname] does contain variables and therefore I suggesting using this for deciding run dcos_install.yml or not.

Tested for fresh installation - worked, for 2nd and all next - doesn't start, which is expected.

Please review/approve/merge