### PR TITLE
[Windows Upgrade] Bugfix/D2IQ-65191 : dcos_install.ps1 location is incorrect, to be looked on up dir upper

### DIFF
--- a/roles/dcos_agent_windows/tasks/dcos_install.yml
+++ b/roles/dcos_agent_windows/tasks/dcos_install.yml
@@ -5,7 +5,7 @@
 
 - name: Windows Installation | Download dcos_install.ps1
   win_get_url:
-    url: "{{ dcos['config']['bootstrap_url'] }}/{{ dcos_version_specifier }}/genconf/serve/windows/prerequisites/dcos_install.ps1"
+    url: "{{ dcos['config']['bootstrap_url'] }}/{{ dcos_version_specifier }}/genconf/serve/windows/dcos_install.ps1"
     dest: "{{ base_windows_dir }}\\dcos_install.ps1"
 
 - name: Windows Installation | DC/OS install


### PR DESCRIPTION
Bugfix/D2IQ-65191 : dcos_install.ps1 location is incorrect, to be looked on up dir upper - at ./windows/
