### PR TITLE
D2IQ-64283 : (bugfix of undefined) added role vars 'dcos_version_specifier' to dcos_agent_windows

### DIFF
--- a/roles/dcos_agent_windows/tasks/dcos_install.yml
+++ b/roles/dcos_agent_windows/tasks/dcos_install.yml
@@ -5,7 +5,7 @@
 
 - name: Windows Installation | Download dcos_install.ps1
   win_get_url:
-    url: "{{ dcos['config']['bootstrap_url'] }}/{{ hostvars[inventory_hostname]['ansible_dcos_installation']['dcos-image-commit'] | default(dcos['version']) }}/genconf/serve/windows/dcos_install.ps1"
+    url: "{{ dcos['config']['bootstrap_url'] }}/{{ dcos_version_specifier }}/genconf/serve/windows/dcos_install.ps1"
     dest: "{{ base_windows_dir }}\\dcos_install.ps1"
 
 - name: Windows Installation | DC/OS install

--- a/roles/dcos_agent_windows/tasks/dcos_install.yml
+++ b/roles/dcos_agent_windows/tasks/dcos_install.yml
@@ -9,7 +9,6 @@
     dest: "{{ base_windows_dir }}\\dcos_install.ps1"
 
 - name: Windows Installation | DC/OS install
-  when: (ansible_local is not defined) or (ansible_local.dcos_installation is not defined) or (ansible_local.dcos_installation['dcos-image-commit'] is not defined)
   block:
     - name: Windows Installation | Run DC/OS agent installation
       win_shell: "{{ base_windows_dir }}\\dcos_install.ps1"

--- a/roles/dcos_agent_windows/tasks/dcos_upgrade.yml
+++ b/roles/dcos_agent_windows/tasks/dcos_upgrade.yml
@@ -1,18 +1,18 @@
 - name: Windows Upgrade | Create upgrade download directory
   win_file:
-    path: "{{ base_windows_dir }}\\{{ hostvars[inventory_hostname]['ansible_dcos_installation']['dcos-image-commit'] | default(dcos['version']) }}"
+    path: "{{ base_windows_dir }}\\{{ dcos_version_specifier }}"
     state: directory
 
 - name: Windows Upgrade | Download dcos_node_upgrade.ps1
   win_get_url:
-    url: "{{ dcos['config']['bootstrap_url'] }}/{{ dcos['version'] }}/genconf/serve/windows/upgrade_from_{{ hostvars[inventory_hostname]['ansible_dcos_installation']['version'] }}/latest/dcos_node_upgrade.ps1"
-    dest: "{{ base_windows_dir }}\\{{ hostvars[inventory_hostname]['ansible_dcos_installation']['dcos-image-commit'] | default(dcos['version']) }}\\dcos_node_upgrade.ps1"
+    url: "{{ dcos['config']['bootstrap_url'] }}/{{ dcos_version_specifier }}/genconf/serve/windows/upgrade_from_{{ hostvars[inventory_hostname]['ansible_dcos_installation']['version'] }}/latest/dcos_node_upgrade.ps1"
+    dest: "{{ base_windows_dir }}\\{{ dcos_version_specifier }}\\dcos_node_upgrade.ps1"
     force: yes
 
 - name: Windows Upgrade | DC/OS Upgrade
   block:
     - name: Windows Upgrade | Run DC/OS agent upgrade
-      win_shell: "{{ base_windows_dir }}\\{{ hostvars[inventory_hostname]['ansible_dcos_installation']['dcos-image-commit'] | default(dcos['version']) }}\\dcos_node_upgrade.ps1"
+      win_shell: "{{ base_windows_dir }}\\{{ dcos_version_specifier }}\\dcos_node_upgrade.ps1"
       register: upgrade_shell_stdout
 
   always:

--- a/roles/dcos_agent_windows/vars/main.yml
+++ b/roles/dcos_agent_windows/vars/main.yml
@@ -1,2 +1,3 @@
 # DCOS Windows params:
 base_windows_dir: "C:\\d2iq\\dcos"
+dcos_version_specifier: "{{ dcos['image_commit'] | default(dcos['version']) }}"


### PR DESCRIPTION
After dcos_upgrade.yml changes merged the bug found in undefined variable while dcos_install.yml call:
```
module.dcos.module.dcos-install.module.dcos-install.null_resource.run_ansible_from_bootstrap_node_to_install_dcos (remote-exec): fatal: [172.16.10.98]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible.vars.hostvars.HostVarsVars object' has no attribute 'ansible_dcos_installation'\n\nThe error appears to have been in '/roles/dcos_agent_windows/tasks/dcos_install.yml': line 6, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Windows Installation | Download dcos_install.ps1\n  ^ here\n"}
```
Reason: ansible_facts are work based on previous dcos-installation detect logic. If there is installation happened previously, then it's defined, otherwise - undefined.
Fix: making a roles/var/mail.yml dcos_version_specifier set similarly like it's done in Linux with set_facts module.
e.q.
```
dcos_version_specifier: "{{ dcos['image_commit'] | default(dcos['version']) }}"
```