### PR TITLE
D2IQ-67197: add "azure/" prefix to Azure Windows fault domain script

### DIFF
--- a/roles/dcos_bootstrap/templates/azurerm/fault-domain-detect-win.j2
+++ b/roles/dcos_bootstrap/templates/azurerm/fault-domain-detect-win.j2
@@ -1,3 +1,3 @@
 $metadata = Invoke-RestMethod -Method GET -Uri http://169.254.169.254/metadata/instance/compute?api-version=2017-04-02 -Headers @{"Metadata"="True"}
-$domain =  '{"fault_domain":{"region":{"name": "' + $metadata.location + '"},"zone":{"name": "' + $metadata.location + '-'+ $metadata.platformFaultDomain + '"}}}'
+$domain =  '{"fault_domain":{"region":{"name": "' + "azure/" + $metadata.location + '"},"zone":{"name": "' + "azure/" + $metadata.location + '-'+ $metadata.platformFaultDomain + '"}}}'
 Write-Output $domain


### PR DESCRIPTION
The change is driven by consistency requirement of both Windows and Linux setups