### PR TITLE
Use Exhibitor certificates if TLS supported

### DIFF
--- a/roles/dcos_master/tasks/dcos_upgrade.yml
+++ b/roles/dcos_master/tasks/dcos_upgrade.yml
@@ -34,8 +34,13 @@
 # TODO: The below checks should be managed from within the DC/OS installer.
 # Check procedure: https://docs.mesosphere.com/1.11/installing/production/upgrading/#dcos-masters
 
-# Step 1 on upgrading prcedure
-- name: "Upgrade: Check for all-green Exhibitor status"
+# Step 1 on upgrading procedure
+- name: "Upgrade: Check Exhibitor TLS state"
+  stat:
+    path: /var/lib/dcos/exhibitor-tls-artifacts/client-key.pem
+  register: exhibtor_tls_key
+
+- name: "Upgrade: Check for all-green Exhibitor status (insecure)"
   shell: |
     set -o pipefail
     curl --silent http://localhost:8181/exhibitor/v1/cluster/status | jq -r '.[].description' | uniq
@@ -45,7 +50,19 @@
   delay: 15
   register: mesos_master_exhibitor_result
   until: mesos_master_exhibitor_result.stdout == 'serving'
-  when: latest_dcos_config_setup_is_installed.rc != 0
+  when: latest_dcos_config_setup_is_installed.rc != 0 and not exhibtor_tls_key.stat.exists
+
+- name: "Upgrade: Check for all-green Exhibitor status (secure)"
+  shell: |
+    set -o pipefail
+    curl --silent --cacert /var/lib/dcos/exhibitor-tls-artifacts/root-cert.pem --cert /var/lib/dcos/exhibitor-tls-artifacts/client-cert.pem --key /var/lib/dcos/exhibitor-tls-artifacts/client-key.pem https://localhost:8181/exhibitor/v1/cluster/status | jq -r '.[].description' | uniq
+  args:
+    warn: false # Curl inside shell is what we need, silence warning.
+  retries: 12
+  delay: 15
+  register: mesos_master_exhibitor_result
+  until: mesos_master_exhibitor_result.stdout == 'serving'
+  when: latest_dcos_config_setup_is_installed.rc != 0 and exhibtor_tls_key.stat.exists
 
 # (Almost) step 2 and 3 on upgrading procedure. Actually getting data from mesos-master requires
 # a valid JWT in strict mode, so for simplicity only checking the two conditions below.


### PR DESCRIPTION
DC/OS Exhibitor can now use TLS for Enterprise clusters with static master lists. Modify the Exhibitor check to use the certificates is present.