### PR TITLE
dcos_requirements: fix centos7 install

### DIFF
--- a/roles/dcos_requirements/tasks/main.yml
+++ b/roles/dcos_requirements/tasks/main.yml
@@ -139,7 +139,7 @@
 
   - name: "Docker installed"
     yum:
-      name: "{{ dcos_docker_pkg_name }}"
+      name: "{{ dcos_docker_pkgs }}"
       update_cache: true
       enablerepo: "{{ rhel_exras_repo_name.stdout | default(omit) }}"
       state: present

--- a/roles/dcos_requirements/vars/CentOS7.yml
+++ b/roles/dcos_requirements/vars/CentOS7.yml
@@ -1,7 +1,9 @@
 dcos_timesync: True
 cloud_time_sync_package: chrony
 onprem_time_sync_package: ntp
-dcos_docker_pkg_name: docker-ce-18.09.2
+dcos_docker_pkgs:
+  - docker-ce-18.09.2
+  - docker-ce-cli-18.09.2
 dcos_containerd_pkg_name: containerd.io-1.2.6
 dcos_prereq_packages:
   - tar

--- a/roles/dcos_requirements/vars/RedHat7.yml
+++ b/roles/dcos_requirements/vars/RedHat7.yml
@@ -1,7 +1,7 @@
 dcos_timesync: True
 cloud_time_sync_package: chrony
 onprem_time_sync_package: ntp
-dcos_docker_pkg_name: docker
+dcos_docker_pkgs: docker
 dcos_prereq_packages:
   - tar
   - xz

--- a/roles/dcos_requirements/vars/RedHat8.yml
+++ b/roles/dcos_requirements/vars/RedHat8.yml
@@ -1,7 +1,7 @@
 dcos_timesync: True
 cloud_time_sync_package: chrony
 onprem_time_sync_package: ntp
-dcos_docker_pkg_name: podman-docker
+dcos_docker_pkgs: podman-docker
 dcos_docker_service_name: podman
 dcos_prereq_packages:
   - tar


### PR DESCRIPTION
Docker has published 19.03 in the stable repo. Since the SPEC for
`docker-ce` does not require a specific verion, when installing
`docker-ce-18.09.2` `docker-ce-cli-19.03.9` gets installed. This leads
to a `DOCKER_API_VERSION` mismatch unless the env is updated to pin the
API version. Instead we should explicitly install the matching CLI
version.