### PR TITLE
fix: use the correct cuda version and specify driver version

### DIFF
--- a/molecule/ec2_gpu/tests/test_default.py
+++ b/molecule/ec2_gpu/tests/test_default.py
@@ -10,8 +10,16 @@ def test_nvidia_smi(host):
     cmd = host.run("sudo nvidia-smi -L")
     assert 'GPU 0' in cmd.stdout
 
-def test_cuda10_caps(host):
+
+def test_cuda11_caps(host):
     nvidia_caps = host.file("/dev/nvidia-caps")
 
-    assert True == nvidia_caps.exists
-    assert False == nvidia_caps.is_directory
+    # only cuda 11 has those files.
+    if nvidia_caps.exists:
+        assert True is nvidia_caps.is_directory
+
+
+def test_cuda10_devices(host):
+    nvidia_dev = host.file("/dev/nvidia0")
+
+    assert True is nvidia_dev.exists

--- a/roles/dcos_gpu/defaults/main.yml
+++ b/roles/dcos_gpu/defaults/main.yml
@@ -8,7 +8,8 @@ nvidia_device_query:
 vault_repo_baseurl: "http://vault.centos.org/{{ os_release_file['content'] |b64decode | regex_search('\\d+\\.\\d+\\.\\d+') }}/os/$basearch/"
 mirror_repo_baseurl: "http://mirror.centos.org/centos/{{ os_release_file['content'] |b64decode | regex_search('\\d+\\.\\d+\\.\\d+') }}/os/$basearch/"
 nvidia_repo_rpm: https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-repo-rhel7-10.1.168-1.x86_64.rpm
-nvidia_cuda_package: cuda-10
+nvidia_cuda_package: cuda-10-2
+nvidia_driver_package: nvidia-driver-branch-440
 
 nvidia_repo_baseurl: https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64
 nvidia_repo_gpgkey: https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/7fa2af80.pub

--- a/roles/dcos_gpu/tasks/nvidia-gpu-CentOS7.yml
+++ b/roles/dcos_gpu/tasks/nvidia-gpu-CentOS7.yml
@@ -78,7 +78,12 @@
     baseurl: "{{ nvidia_repo_baseurl }}"
     gpgkey: "{{ nvidia_repo_gpgkey }}"
     gpgcheck: true
-- name: Install cuda drivers and tools
+- name: Install nvidia driver
+  yum:
+    name:
+      - "{{ nvidia_driver_package }}"
+    state: present
+- name: Install cuda package and tools
   yum:
     name:
       - "{{ nvidia_cuda_package }}"


### PR DESCRIPTION
- fixed wrong cuda package naming
- added ability for a specific driver
- fixed tests. `/dev/nvidia-caps` is exepected to be a folder with cuda 11

For now we use `cuda-10-2` and `nvidia-driver-branch-440` as mesos does not expect a folder in `/dev/nvidia*`