### PR TITLE
fix: docker-py latest does not suppoer py2

### DIFF
--- a/roles/dcos_bootstrap/tasks/main.yml
+++ b/roles/dcos_bootstrap/tasks/main.yml
@@ -49,6 +49,7 @@
 - name: Install python docker bindings
   pip:
     name: docker
+    version: 4.4.4
     state: present
   register: dcos_pip_docker_install
   retries: 3


### PR DESCRIPTION
docker-py 5.0.0 got released on 2021-04-06 https://pypi.org/project/docker/5.0.0/ this version does not support py2 anymore.

With this fix we're using a static version of `4.4.4`