### PR TITLE
bootstrap: pin `websocket-client`

### DIFF
--- a/roles/dcos_bootstrap/tasks/main.yml
+++ b/roles/dcos_bootstrap/tasks/main.yml
@@ -48,8 +48,9 @@
 
 - name: Install python docker bindings
   pip:
-    name: docker
-    version: 4.4.4
+    name:
+      - docker==4.4.4
+      - websocket-client<1.0.0
     state: present
   register: dcos_pip_docker_install
   retries: 3


### PR DESCRIPTION
`docker-py` requires `websocket-client >= 0.32.0` but
`websocket-client` `v1.0.0` has been released which does not support
python2.